### PR TITLE
injected_methods Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ gem 'interjectable'
 
 ## Usage
 
-Interjectable has one module (`Interjectable`) and two methods. It also includes both an instance and singleton helper method `injected_methods(include_super = true)` to track what dependency methods have been created. Use them like so!
+Interjectable has one module (`Interjectable`) and two main methods for defining dependencies,
+`inject` and `inject_static`. Use them like so!
 
 ```ruby
 class MyClass
@@ -25,21 +26,17 @@ class MyClass
   # defines helper methods on instances that memoize values statically,
   # shared across all instances
   inject_static(:shared_value) { ENV["SOME_VALUE"] }
-
-  def do_something
-    injected_methods # => [:injected_methods, :dependency, :dependency=, :other_dependency, :other_dependency=, :shared_value, :shared_value=]
-    MyClass.injected_methods == injected_methods # => true
-  end
 end
+```
 
-class MySubClass < MyClass
-  inject(:sub_dependency) { SubClass.new }
+It also includes introspection method `injected_methods(include_super = true)` (both instance and class-level)
+to track what dependency methods have been created.
 
-  def do_something
-    injected_methods # => [:injected_methods, :dependency, :dependency=, :other_dependency, :other_dependency=, :shared_value, :shared_value=, :sub_dependency, :sub_dependency=]
-    injected_methods(false) # => [:injected_methods, :sub_dependency, :sub_dependency=]
-  end
-end
+```ruby
+MyClass.injected_methods
+# => [:injected_methods, :dependency, :dependency=, :other_dependency, :other_dependency=,
+MyClass.new.injected_methods
+# => [:injected_methods, :dependency, :dependency=, :other_dependency, :other_dependency=,
 ```
 
 This replaces a pattern we've used before, adding default dependencies in the constructor, or as memoized methods.

--- a/lib/interjectable.rb
+++ b/lib/interjectable.rb
@@ -17,11 +17,13 @@ module Interjectable
 
   module InstanceMethods
     def injected_methods(include_super = true)
-      injected = self.class.instance_variable_get(:@injected_methods).to_a
+      injected = self.class.instance_variable_get(:@injected_methods).to_a +
+        self.class.instance_variable_get(:@static_injected_methods).to_a
 
       if include_super
         super_injected = self.class.ancestors.flat_map do |klass|
-          klass.instance_variable_get(:@injected_methods).to_a
+          klass.instance_variable_get(:@injected_methods).to_a +
+            klass.instance_variable_get(:@static_injected_methods).to_a
         end
 
         [
@@ -120,12 +122,11 @@ module Interjectable
 
     # @return [Array<Symbol>]
     def injected_methods(include_super = true)
-      injected = @injected_methods.to_a + @static_injected_methods.to_a
+      injected = @static_injected_methods.to_a
 
       if include_super
         super_injected = ancestors.flat_map do |klass|
-          klass.instance_variable_get(:@injected_methods).to_a +
-            klass.instance_variable_get(:@static_injected_methods).to_a
+          klass.instance_variable_get(:@static_injected_methods).to_a
         end
 
         [

--- a/lib/interjectable.rb
+++ b/lib/interjectable.rb
@@ -7,10 +7,18 @@ module Interjectable
 
   def self.included(mod)
     mod.send(:extend, ClassMethods)
+    mod.send(:include, InstanceMethods)
   end
 
   def self.extended(mod)
     mod.send(:extend, ClassMethods)
+    mod.send(:include, InstanceMethods)
+  end
+
+  module InstanceMethods
+    def injected_methods(include_super = true)
+      self.class.injected_methods(include_super)
+    end
   end
 
   module ClassMethods
@@ -27,10 +35,6 @@ module Interjectable
     #   def dependency
     #     @dependency ||= instance_eval(&default_block)
     #   end
-    #
-    # Also defines both an instance and singleton helper method `injected_methods(include_super = true)`,
-    # which tracks injected dependencies regardless of whether the dependency was injected on the instance or class.
-    # It includes itself as one of the injected methods (i.e. `injected_methods` will be present).
     def inject(dependency, &default_block)
       if instance_methods(false).include?(dependency)
         raise MethodAlreadyDefined, "#{dependency} is already defined"
@@ -47,33 +51,8 @@ module Interjectable
         end
       end
 
-      injected_methods = :injected_methods
-      injected_methods_ivar = :"@#{injected_methods}"
-      setter = :"#{dependency}="
-
-      unless instance_variable_defined?(injected_methods_ivar)
-        instance_variable_set(injected_methods_ivar, [injected_methods])
-      end
-      instance_variable_get(injected_methods_ivar).append(dependency, setter)
-
-      injecting_class = self
-
-      define_method(injected_methods) do |include_super = true|
-        injecting_class.send(injected_methods, include_super)
-      end
-
-      define_singleton_method(injected_methods) do |include_super = true|
-        unless injecting_class.instance_variable_defined?(injected_methods_ivar)
-          injecting_class.instance_variable_set(injected_methods_ivar, [injected_methods])
-        end
-
-        if include_super && injecting_class.superclass.respond_to?(injected_methods)
-          return [*injecting_class.instance_variable_get(injected_methods_ivar),
-                  *injecting_class.superclass.send(injected_methods, include_super)].uniq
-        end
-
-        injecting_class.instance_variable_get(injected_methods_ivar)
-      end
+      @injected_methods ||= []
+      @injected_methods += [dependency, :"#{dependency}="]
     end
 
     # Defines helper methods on instances that memoize values per-class.
@@ -91,10 +70,6 @@ module Interjectable
     #   def dependency
     #     @@dependency ||= instance_eval(&default_block)
     #   end
-    #
-    # Also defines both an instance and singleton helper method `injected_methods(include_super = true)`,
-    # which tracks injected dependencies regardless of whether the dependency was injected on the instance or class.
-    # It includes itself as one of the injected methods (i.e. `injected_methods` will be present).
     def inject_static(dependency, &default_block)
       if instance_methods(false).include?(dependency) || methods(false).include?(dependency)
         raise MethodAlreadyDefined, "#{dependency} is already defined"
@@ -125,29 +100,26 @@ module Interjectable
         end
       end
 
-      injected_methods = :injected_methods
-      injected_methods_ivar = :"@#{injected_methods}"
+      @injected_methods ||= []
+      @injected_methods += [dependency, :"#{dependency}="]
+    end
 
-      unless injecting_class.instance_variable_defined?(injected_methods_ivar)
-        injecting_class.instance_variable_set(injected_methods_ivar, [injected_methods])
-      end
-      injecting_class.instance_variable_get(injected_methods_ivar).append(dependency, setter)
+    # @return [Array<Symbol>]
+    def injected_methods(include_super = true)
+      injected = @injected_methods.to_a
 
-      define_method(injected_methods) do |include_super = true|
-        injecting_class.send(injected_methods, include_super)
-      end
-
-      define_singleton_method(injected_methods) do |include_super = true|
-        unless injecting_class.instance_variable_defined?(injected_methods_ivar)
-          injecting_class.instance_variable_set(injected_methods_ivar, [injected_methods])
+      if include_super
+        super_injected = ancestors.flat_map do |klass|
+          klass.instance_variable_get(:@injected_methods).to_a
         end
 
-        if include_super && injecting_class.superclass.respond_to?(injected_methods)
-          return [*injecting_class.instance_variable_get(injected_methods_ivar),
-                  *injecting_class.superclass.send(injected_methods, include_super)].uniq
-        end
-
-        injecting_class.instance_variable_get(injected_methods_ivar)
+        [
+          :injected_methods,
+          *super_injected,
+          *injected,
+        ].uniq
+      else
+        [:injected_methods, *injected]
       end
     end
   end

--- a/spec/interjectable_spec.rb
+++ b/spec/interjectable_spec.rb
@@ -32,7 +32,7 @@ describe Interjectable do
         instance.some_dependency = 'aaa'
         expect(instance.some_dependency).to eq('aaa')
 
-        expect_injected_methods(klass, instance, true, :some_dependency)
+        # expect_injected_methods(klass, instance, true, :some_dependency)
       end
 
       it "lazy-loads the default block" do
@@ -40,7 +40,7 @@ describe Interjectable do
         expect(instance.some_dependency).to eq(:service)
         expect(instance.instance_variable_get("@some_dependency")).not_to be_nil
 
-        expect_injected_methods(klass, instance, true, :some_dependency)
+        # expect_injected_methods(klass, instance, true, :some_dependency)
       end
 
       it "allows transitive dependencies (via instance_eval)" do
@@ -48,7 +48,7 @@ describe Interjectable do
         klass.inject(:second_dependency) { :value }
 
         expect(instance.first_dependency).to eq(:value)
-        expect_injected_methods(klass, instance, true, :some_dependency, :first_dependency, :second_dependency)
+        # expect_injected_methods(klass, instance, true, :some_dependency, :first_dependency, :second_dependency)
       end
 
       it "calls dependency block once, even with a falsy value" do
@@ -58,7 +58,7 @@ describe Interjectable do
         2.times { expect(instance.some_falsy_dependency).to be_nil }
         expect(count).to eq(1)
 
-        expect_injected_methods(klass, instance, true, :some_dependency, :some_falsy_dependency)
+        # expect_injected_methods(klass, instance, true, :some_dependency, :some_falsy_dependency)
       end
 
       it "errors when injecting the same dependency multiple times" do
@@ -81,7 +81,7 @@ describe Interjectable do
         instance.foo = 2
         expect(instance.good_dependency).to eq(2)
 
-        expect_injected_methods(klass, instance, true, :some_dependency, :good_dependency)
+        # expect_injected_methods(klass, instance, true, :some_dependency, :good_dependency)
       end
 
       context "with a dependency on another class" do
@@ -95,7 +95,7 @@ describe Interjectable do
           instance.some_other_class = :fake_other_class
 
           expect(instance.some_other_class).to eq(:fake_other_class)
-          expect_injected_methods(klass, instance, true, :some_dependency, :some_other_class)
+          # expect_injected_methods(klass, instance, true, :some_dependency, :some_other_class)
         end
       end
 
@@ -107,8 +107,8 @@ describe Interjectable do
           subclass.inject(:some_dependency) { :some_other_value }
           expect(subclass_instance.some_dependency).to eq(:some_other_value)
 
-          expect_injected_methods(klass, instance, true, :some_dependency)
-          expect_injected_methods(subclass, subclass_instance, true, :some_dependency)
+          # expect_injected_methods(klass, instance, true, :some_dependency)
+          # expect_injected_methods(subclass, subclass_instance, true, :some_dependency)
         end
 
         it "allows injection on the subclass without injecting on the superclass" do
@@ -116,11 +116,11 @@ describe Interjectable do
           expect(subclass_instance.subclass_dependency).to eq(:brand_new_value)
           expect { instance.subclass_dependency }.to raise_error(NoMethodError)
 
-          expect_injected_methods(klass, instance, true, :some_dependency)
-          expect_injected_methods(klass, instance, false, :some_dependency)
+          # expect_injected_methods(klass, instance, true, :some_dependency)
+          # expect_injected_methods(klass, instance, false, :some_dependency)
 
-          expect_injected_methods(subclass, subclass_instance, true, :some_dependency, :subclass_dependency)
-          expect_injected_methods(subclass, subclass_instance, false, :subclass_dependency)
+          # expect_injected_methods(subclass, subclass_instance, true, :some_dependency, :subclass_dependency)
+          # expect_injected_methods(subclass, subclass_instance, false, :subclass_dependency)
         end
 
         context "with a chain of subclasses" do
@@ -131,15 +131,15 @@ describe Interjectable do
             subclass.inject(:subclass_dependency) { :subclass_value }
             lower_subclass.inject(:lower_subclass_dependency) { :lower_subclass_value }
 
-            expect_injected_methods(klass, instance, true, :some_dependency)
-            expect_injected_methods(klass, instance, false, :some_dependency)
+            # expect_injected_methods(klass, instance, true, :some_dependency)
+            # expect_injected_methods(klass, instance, false, :some_dependency)
 
-            expect_injected_methods(subclass, subclass_instance, true, :some_dependency, :subclass_dependency)
-            expect_injected_methods(subclass, subclass_instance, false, :subclass_dependency)
+            # expect_injected_methods(subclass, subclass_instance, true, :some_dependency, :subclass_dependency)
+            # expect_injected_methods(subclass, subclass_instance, false, :subclass_dependency)
 
-            expect_injected_methods(lower_subclass, lower_subclass_instance, true,
-                                    :some_dependency, :subclass_dependency, :lower_subclass_dependency)
-            expect_injected_methods(lower_subclass, lower_subclass_instance, false, :lower_subclass_dependency)
+            # expect_injected_methods(lower_subclass, lower_subclass_instance, true,
+            #                         :some_dependency, :subclass_dependency, :lower_subclass_dependency)
+            # expect_injected_methods(lower_subclass, lower_subclass_instance, false, :lower_subclass_dependency)
           end
         end
       end
@@ -160,16 +160,16 @@ describe Interjectable do
         instance.static_dependency = 'aaa'
         expect(instance.static_dependency).to eq('aaa')
 
-        expect_injected_methods(klass, instance, true, :static_dependency)
-        expect_injected_methods(klass, other_instance, true, :static_dependency)
+        # expect_injected_methods(klass, instance, true, :static_dependency)
+        # expect_injected_methods(klass, other_instance, true, :static_dependency)
       end
 
       it "adds a class method and setter" do
         klass.static_dependency = 'aaa'
         expect(klass.static_dependency).to eq('aaa')
 
-        expect_injected_methods(klass, instance, true, :static_dependency)
-        expect_injected_methods(klass, other_instance, true, :static_dependency)
+        # expect_injected_methods(klass, instance, true, :static_dependency)
+        # expect_injected_methods(klass, other_instance, true, :static_dependency)
       end
 
       it "shares a value across all instances of a class" do
@@ -177,8 +177,8 @@ describe Interjectable do
         expect(other_instance.static_dependency).to eq('bbb')
         expect(klass.static_dependency).to eq('bbb')
 
-        expect_injected_methods(klass, instance, true, :static_dependency)
-        expect_injected_methods(klass, other_instance, true, :static_dependency)
+        # expect_injected_methods(klass, instance, true, :static_dependency)
+        # expect_injected_methods(klass, other_instance, true, :static_dependency)
       end
 
       it "calls its dependency block once across all instances" do
@@ -191,8 +191,8 @@ describe Interjectable do
 
         expect(count).to eq(1)
 
-        expect_injected_methods(klass, instance, true, :static_dependency, :falsy_static_dependency)
-        expect_injected_methods(klass, other_instance, true, :static_dependency, :falsy_static_dependency)
+        # expect_injected_methods(klass, instance, true, :static_dependency, :falsy_static_dependency)
+        # expect_injected_methods(klass, other_instance, true, :static_dependency, :falsy_static_dependency)
       end
 
       it "errors when inject_static-ing a dependency multiple times" do
@@ -234,9 +234,9 @@ describe Interjectable do
           expect(subclass_instance.static_dependency).to eq('ccc')
           expect(subclass.static_dependency).to eq('ccc')
 
-          expect_injected_methods(klass, instance, true, :static_dependency)
-          expect_injected_methods(klass, other_instance, true, :static_dependency)
-          expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
+          # expect_injected_methods(klass, instance, true, :static_dependency)
+          # expect_injected_methods(klass, other_instance, true, :static_dependency)
+          # expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
         end
 
         it "does not error if the method exists on the super klass" do
@@ -244,9 +244,9 @@ describe Interjectable do
           expect(subclass_instance.static_dependency).to eq(:some_other_value)
           expect(subclass.static_dependency).to eq(:some_other_value)
 
-          expect_injected_methods(klass, instance, true, :static_dependency)
-          expect_injected_methods(klass, other_instance, true, :static_dependency)
-          expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
+          # expect_injected_methods(klass, instance, true, :static_dependency)
+          # expect_injected_methods(klass, other_instance, true, :static_dependency)
+          # expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
         end
 
         it "does not error when lazily setting the dep from a subclass first" do
@@ -254,18 +254,18 @@ describe Interjectable do
           expect(klass.static_dependency).to eq(:some_value)
           expect(subclass.static_dependency).to eq(:some_value)
 
-          expect_injected_methods(klass, instance, true, :static_dependency)
-          expect_injected_methods(klass, other_instance, true, :static_dependency)
-          expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
+          # expect_injected_methods(klass, instance, true, :static_dependency)
+          # expect_injected_methods(klass, other_instance, true, :static_dependency)
+          # expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
         end
 
         it "only defines the class variable on the injecting class" do
           expect(subclass.static_dependency).to eq(:some_value)
           expect(klass.class_variable_get(:@@static_dependency)).to eq(:some_value)
 
-          expect_injected_methods(klass, instance, true, :static_dependency)
-          expect_injected_methods(klass, other_instance, true, :static_dependency)
-          expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
+          # expect_injected_methods(klass, instance, true, :static_dependency)
+          # expect_injected_methods(klass, other_instance, true, :static_dependency)
+          # expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
         end
 
         it "allows injection on the subclass without injecting on the superclass" do
@@ -274,11 +274,11 @@ describe Interjectable do
           expect { klass.static_subclass_dependency }.to raise_error(NoMethodError)
           expect { instance.static_subclass_dependency }.to raise_error(NoMethodError)
 
-          expect_injected_methods(klass, instance, true, :static_dependency)
-          expect_injected_methods(klass, instance, false, :static_dependency)
+          # expect_injected_methods(klass, instance, true, :static_dependency)
+          # expect_injected_methods(klass, instance, false, :static_dependency)
 
-          expect_injected_methods(subclass, subclass_instance, true, :static_dependency, :static_subclass_dependency)
-          expect_injected_methods(subclass, subclass_instance, false, :static_subclass_dependency)
+          # expect_injected_methods(subclass, subclass_instance, true, :static_dependency, :static_subclass_dependency)
+          # expect_injected_methods(subclass, subclass_instance, false, :static_subclass_dependency)
         end
 
         context "with a chain of subclasses" do
@@ -289,18 +289,140 @@ describe Interjectable do
             subclass.inject_static(:static_subclass_dependency) { :subclass_value }
             lower_subclass.inject_static(:static_lower_subclass_dependency) { :lower_subclass_value }
 
-            expect_injected_methods(klass, instance, true, :static_dependency)
-            expect_injected_methods(klass, instance, false, :static_dependency)
+            # expect_injected_methods(klass, instance, true, :static_dependency)
+            # expect_injected_methods(klass, instance, false, :static_dependency)
 
-            expect_injected_methods(subclass, subclass_instance, true, :static_dependency, :static_subclass_dependency)
-            expect_injected_methods(subclass, subclass_instance, false, :static_subclass_dependency)
+            # expect_injected_methods(subclass, subclass_instance, true, :static_dependency, :static_subclass_dependency)
+            # expect_injected_methods(subclass, subclass_instance, false, :static_subclass_dependency)
 
-            expect_injected_methods(lower_subclass, lower_subclass_instance, true,
-                                    :static_dependency, :static_subclass_dependency, :static_lower_subclass_dependency)
-            expect_injected_methods(lower_subclass, lower_subclass_instance, false, :static_lower_subclass_dependency)
+            # expect_injected_methods(lower_subclass, lower_subclass_instance, true,
+            #                         :static_dependency, :static_subclass_dependency, :static_lower_subclass_dependency)
+            # expect_injected_methods(lower_subclass, lower_subclass_instance, false, :static_lower_subclass_dependency)
           end
         end
       end
+    end
+
+    describe "#injected_methods" do
+      before do
+        klass.inject(:a) { :a }
+        klass.inject_static(:b) { :b }
+      end
+
+      it "lists injected methods on the instance" do
+        expect(instance.injected_methods).to match_array(
+          [
+            :injected_methods, :a, :a=, :b, :b=,
+          ],
+        )
+      end
+
+      context "with a subclass" do
+        let(:subclass) do
+          Class.new(klass) do
+            inject(:c) { :c }
+          end
+        end
+        let(:include_super) { true }
+        let(:subclass_instance) { subclass.new }
+
+        it "includes super methods by default" do
+          expect(subclass_instance.injected_methods(include_super)).to match_array(
+            [
+              :injected_methods,
+              :a,
+              :a=,
+              :b,
+              :b=,
+              :c,
+              :c=,
+            ],
+          )
+        end
+
+        context "with include_super = false" do
+          let(:include_super) { false }
+
+          it "does not include super methods" do
+            injected_methods = subclass_instance.injected_methods(include_super)
+
+            expect(injected_methods).to_not include(:a)
+            expect(injected_methods).to_not include(:a=)
+            expect(injected_methods).to_not include(:b)
+            expect(injected_methods).to_not include(:b=)
+
+            expect(injected_methods).to match_array(
+              [
+                :injected_methods,
+                :c,
+                :c=,
+              ],
+            )
+          end
+        end
+      end
+    end
+
+    describe ".injected_methods" do
+      before do
+        klass.inject(:a) { :a }
+        klass.inject_static(:b) { :b }
+      end
+
+      it "lists injected methods on the instance" do
+        expect(klass.injected_methods).to match_array(
+          [
+            :injected_methods, :a, :a=, :b, :b=,
+          ],
+        )
+      end
+
+      context "with a subclass" do
+        let(:subclass) do
+          Class.new(klass) do
+            inject(:c) { :c }
+          end
+        end
+        let(:include_super) { true }
+
+        it "includes super methods by default" do
+          expect(subclass.injected_methods(include_super)).to match_array(
+            [
+              :injected_methods,
+              :a,
+              :a=,
+              :b,
+              :b=,
+              :c,
+              :c=
+            ],
+          )
+        end
+
+        context "with include_super = false" do
+          let(:include_super) { false }
+
+          it "does not include super methods" do
+            injected_methods = subclass.injected_methods(include_super)
+
+            expect(injected_methods).to_not include(:a)
+            expect(injected_methods).to_not include(:a=)
+            expect(injected_methods).to_not include(:b)
+            expect(injected_methods).to_not include(:b=)
+
+            expect(injected_methods).to match_array(
+              [
+                :injected_methods,
+                :c,
+                :c=,
+              ],
+            )
+          end
+        end
+      end
+    end
+
+    describe ".static_injected_methods" do
     end
   end
 

--- a/spec/interjectable_spec.rb
+++ b/spec/interjectable_spec.rb
@@ -6,19 +6,6 @@ describe Interjectable do
   shared_examples_for "an interjectable class" do
     let(:instance) { klass.new }
 
-    def expect_injected_methods(injecting_class, class_instance, include_super, *getter_methods)
-      expect(injecting_class.injected_methods(include_super))
-        .to match_array(class_instance.injected_methods(include_super))
-
-      setter_methods = getter_methods.map { |m| :"#{m}=" }
-      expected_methods = getter_methods + setter_methods + [:injected_methods]
-      if include_super && injecting_class.superclass.respond_to?(:injected_methods)
-        expected_methods.append(*injecting_class.superclass.injected_methods(include_super)).uniq!
-      end
-
-      expect(injecting_class.injected_methods(include_super)).to match_array(expected_methods)
-    end
-
     describe "#inject" do
       before do
         klass.inject(:some_dependency) { :service }
@@ -31,16 +18,12 @@ describe Interjectable do
       it "adds an instance method getter and setter" do
         instance.some_dependency = 'aaa'
         expect(instance.some_dependency).to eq('aaa')
-
-        # expect_injected_methods(klass, instance, true, :some_dependency)
       end
 
       it "lazy-loads the default block" do
         expect(instance.instance_variable_get("@some_dependency")).to be_nil
         expect(instance.some_dependency).to eq(:service)
         expect(instance.instance_variable_get("@some_dependency")).not_to be_nil
-
-        # expect_injected_methods(klass, instance, true, :some_dependency)
       end
 
       it "allows transitive dependencies (via instance_eval)" do
@@ -48,7 +31,6 @@ describe Interjectable do
         klass.inject(:second_dependency) { :value }
 
         expect(instance.first_dependency).to eq(:value)
-        # expect_injected_methods(klass, instance, true, :some_dependency, :first_dependency, :second_dependency)
       end
 
       it "calls dependency block once, even with a falsy value" do
@@ -57,8 +39,6 @@ describe Interjectable do
 
         2.times { expect(instance.some_falsy_dependency).to be_nil }
         expect(count).to eq(1)
-
-        # expect_injected_methods(klass, instance, true, :some_dependency, :some_falsy_dependency)
       end
 
       it "errors when injecting the same dependency multiple times" do
@@ -80,8 +60,6 @@ describe Interjectable do
         klass.inject(:good_dependency) { foo }
         instance.foo = 2
         expect(instance.good_dependency).to eq(2)
-
-        # expect_injected_methods(klass, instance, true, :some_dependency, :good_dependency)
       end
 
       context "with a dependency on another class" do
@@ -95,7 +73,6 @@ describe Interjectable do
           instance.some_other_class = :fake_other_class
 
           expect(instance.some_other_class).to eq(:fake_other_class)
-          # expect_injected_methods(klass, instance, true, :some_dependency, :some_other_class)
         end
       end
 
@@ -106,21 +83,12 @@ describe Interjectable do
         it "does not error if the method exists on the superclass" do
           subclass.inject(:some_dependency) { :some_other_value }
           expect(subclass_instance.some_dependency).to eq(:some_other_value)
-
-          # expect_injected_methods(klass, instance, true, :some_dependency)
-          # expect_injected_methods(subclass, subclass_instance, true, :some_dependency)
         end
 
         it "allows injection on the subclass without injecting on the superclass" do
           subclass.inject(:subclass_dependency) { :brand_new_value }
           expect(subclass_instance.subclass_dependency).to eq(:brand_new_value)
           expect { instance.subclass_dependency }.to raise_error(NoMethodError)
-
-          # expect_injected_methods(klass, instance, true, :some_dependency)
-          # expect_injected_methods(klass, instance, false, :some_dependency)
-
-          # expect_injected_methods(subclass, subclass_instance, true, :some_dependency, :subclass_dependency)
-          # expect_injected_methods(subclass, subclass_instance, false, :subclass_dependency)
         end
 
         context "with a chain of subclasses" do
@@ -130,16 +98,6 @@ describe Interjectable do
           it "retrieves injected methods from all ancestors when requested" do
             subclass.inject(:subclass_dependency) { :subclass_value }
             lower_subclass.inject(:lower_subclass_dependency) { :lower_subclass_value }
-
-            # expect_injected_methods(klass, instance, true, :some_dependency)
-            # expect_injected_methods(klass, instance, false, :some_dependency)
-
-            # expect_injected_methods(subclass, subclass_instance, true, :some_dependency, :subclass_dependency)
-            # expect_injected_methods(subclass, subclass_instance, false, :subclass_dependency)
-
-            # expect_injected_methods(lower_subclass, lower_subclass_instance, true,
-            #                         :some_dependency, :subclass_dependency, :lower_subclass_dependency)
-            # expect_injected_methods(lower_subclass, lower_subclass_instance, false, :lower_subclass_dependency)
           end
         end
       end
@@ -159,26 +117,17 @@ describe Interjectable do
       it "adds an instance method and setter" do
         instance.static_dependency = 'aaa'
         expect(instance.static_dependency).to eq('aaa')
-
-        # expect_injected_methods(klass, instance, true, :static_dependency)
-        # expect_injected_methods(klass, other_instance, true, :static_dependency)
       end
 
       it "adds a class method and setter" do
         klass.static_dependency = 'aaa'
         expect(klass.static_dependency).to eq('aaa')
-
-        # expect_injected_methods(klass, instance, true, :static_dependency)
-        # expect_injected_methods(klass, other_instance, true, :static_dependency)
       end
 
       it "shares a value across all instances of a class" do
         instance.static_dependency = 'bbb'
         expect(other_instance.static_dependency).to eq('bbb')
         expect(klass.static_dependency).to eq('bbb')
-
-        # expect_injected_methods(klass, instance, true, :static_dependency)
-        # expect_injected_methods(klass, other_instance, true, :static_dependency)
       end
 
       it "calls its dependency block once across all instances" do
@@ -190,9 +139,6 @@ describe Interjectable do
         expect(klass.falsy_static_dependency).to be_nil
 
         expect(count).to eq(1)
-
-        # expect_injected_methods(klass, instance, true, :static_dependency, :falsy_static_dependency)
-        # expect_injected_methods(klass, other_instance, true, :static_dependency, :falsy_static_dependency)
       end
 
       it "errors when inject_static-ing a dependency multiple times" do
@@ -233,39 +179,23 @@ describe Interjectable do
           instance.static_dependency = 'ccc'
           expect(subclass_instance.static_dependency).to eq('ccc')
           expect(subclass.static_dependency).to eq('ccc')
-
-          # expect_injected_methods(klass, instance, true, :static_dependency)
-          # expect_injected_methods(klass, other_instance, true, :static_dependency)
-          # expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
         end
 
         it "does not error if the method exists on the super klass" do
           subclass.inject_static(:static_dependency) { :some_other_value }
           expect(subclass_instance.static_dependency).to eq(:some_other_value)
           expect(subclass.static_dependency).to eq(:some_other_value)
-
-          # expect_injected_methods(klass, instance, true, :static_dependency)
-          # expect_injected_methods(klass, other_instance, true, :static_dependency)
-          # expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
         end
 
         it "does not error when lazily setting the dep from a subclass first" do
           expect(subclass.static_dependency).to eq(:some_value)
           expect(klass.static_dependency).to eq(:some_value)
           expect(subclass.static_dependency).to eq(:some_value)
-
-          # expect_injected_methods(klass, instance, true, :static_dependency)
-          # expect_injected_methods(klass, other_instance, true, :static_dependency)
-          # expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
         end
 
         it "only defines the class variable on the injecting class" do
           expect(subclass.static_dependency).to eq(:some_value)
           expect(klass.class_variable_get(:@@static_dependency)).to eq(:some_value)
-
-          # expect_injected_methods(klass, instance, true, :static_dependency)
-          # expect_injected_methods(klass, other_instance, true, :static_dependency)
-          # expect_injected_methods(subclass, subclass_instance, true, :static_dependency)
         end
 
         it "allows injection on the subclass without injecting on the superclass" do
@@ -273,12 +203,6 @@ describe Interjectable do
           expect(subclass_instance.static_subclass_dependency).to eq(:brand_new_value)
           expect { klass.static_subclass_dependency }.to raise_error(NoMethodError)
           expect { instance.static_subclass_dependency }.to raise_error(NoMethodError)
-
-          # expect_injected_methods(klass, instance, true, :static_dependency)
-          # expect_injected_methods(klass, instance, false, :static_dependency)
-
-          # expect_injected_methods(subclass, subclass_instance, true, :static_dependency, :static_subclass_dependency)
-          # expect_injected_methods(subclass, subclass_instance, false, :static_subclass_dependency)
         end
 
         context "with a chain of subclasses" do
@@ -288,16 +212,6 @@ describe Interjectable do
           it "retrieves injected methods from all ancestors when requested" do
             subclass.inject_static(:static_subclass_dependency) { :subclass_value }
             lower_subclass.inject_static(:static_lower_subclass_dependency) { :lower_subclass_value }
-
-            # expect_injected_methods(klass, instance, true, :static_dependency)
-            # expect_injected_methods(klass, instance, false, :static_dependency)
-
-            # expect_injected_methods(subclass, subclass_instance, true, :static_dependency, :static_subclass_dependency)
-            # expect_injected_methods(subclass, subclass_instance, false, :static_subclass_dependency)
-
-            # expect_injected_methods(lower_subclass, lower_subclass_instance, true,
-            #                         :static_dependency, :static_subclass_dependency, :static_lower_subclass_dependency)
-            # expect_injected_methods(lower_subclass, lower_subclass_instance, false, :static_lower_subclass_dependency)
           end
         end
       end
@@ -309,12 +223,16 @@ describe Interjectable do
         klass.inject_static(:b) { :b }
       end
 
-      it "lists injected methods on the instance" do
-        expect(instance.injected_methods).to match_array(
+      it "lists injected methods on the instance but not the class" do
+        injected_methods = instance.injected_methods
+
+        expect(injected_methods).to match_array(
           [
-            :injected_methods, :a, :a=, :b, :b=,
+            :injected_methods, :a, :a=,
           ],
         )
+        expect(injected_methods).to_not include(:b)
+        expect(injected_methods).to_not include(:b=)
       end
 
       context "with a subclass" do
@@ -327,17 +245,19 @@ describe Interjectable do
         let(:subclass_instance) { subclass.new }
 
         it "includes super methods by default" do
-          expect(subclass_instance.injected_methods(include_super)).to match_array(
+          injected_methods = subclass_instance.injected_methods(include_super)
+
+          expect(injected_methods).to match_array(
             [
               :injected_methods,
               :a,
               :a=,
-              :b,
-              :b=,
               :c,
               :c=,
             ],
           )
+          expect(injected_methods).to_not include(:b)
+          expect(injected_methods).to_not include(:b=)
         end
 
         context "with include_super = false" do
@@ -369,7 +289,7 @@ describe Interjectable do
         klass.inject_static(:b) { :b }
       end
 
-      it "lists injected methods on the instance" do
+      it "lists injected methods on the instance and class" do
         expect(klass.injected_methods).to match_array(
           [
             :injected_methods, :a, :a=, :b, :b=,
@@ -420,9 +340,6 @@ describe Interjectable do
           end
         end
       end
-    end
-
-    describe ".static_injected_methods" do
     end
   end
 

--- a/spec/interjectable_spec.rb
+++ b/spec/interjectable_spec.rb
@@ -223,16 +223,14 @@ describe Interjectable do
         klass.inject_static(:b) { :b }
       end
 
-      it "lists injected methods on the instance but not the class" do
+      it "lists injected methods on the instance and static ones too" do
         injected_methods = instance.injected_methods
 
         expect(injected_methods).to match_array(
           [
-            :injected_methods, :a, :a=,
+            :injected_methods, :a, :a=, :b, :b=,
           ],
         )
-        expect(injected_methods).to_not include(:b)
-        expect(injected_methods).to_not include(:b=)
       end
 
       context "with a subclass" do
@@ -252,12 +250,12 @@ describe Interjectable do
               :injected_methods,
               :a,
               :a=,
+              :b,
+              :b=,
               :c,
               :c=,
             ],
           )
-          expect(injected_methods).to_not include(:b)
-          expect(injected_methods).to_not include(:b=)
         end
 
         context "with include_super = false" do
@@ -289,34 +287,43 @@ describe Interjectable do
         klass.inject_static(:b) { :b }
       end
 
-      it "lists injected methods on the instance and class" do
-        expect(klass.injected_methods).to match_array(
+      it "lists static injected methods class" do
+        injected_methods = klass.injected_methods
+
+        expect(injected_methods).to match_array(
           [
-            :injected_methods, :a, :a=, :b, :b=,
+            :injected_methods, :b, :b=,
           ],
         )
+        expect(injected_methods).to_not include(:a)
+        expect(injected_methods).to_not include(:a=)
       end
 
       context "with a subclass" do
         let(:subclass) do
           Class.new(klass) do
             inject(:c) { :c }
+            inject_static(:d) { :d }
           end
         end
         let(:include_super) { true }
 
         it "includes super methods by default" do
-          expect(subclass.injected_methods(include_super)).to match_array(
+          injected_methods = subclass.injected_methods(include_super)
+
+          expect(injected_methods).to match_array(
             [
               :injected_methods,
-              :a,
-              :a=,
               :b,
               :b=,
-              :c,
-              :c=
+              :d,
+              :d=
             ],
           )
+          expect(injected_methods).to_not include(:a), 'skips instance methods'
+          expect(injected_methods).to_not include(:a=), 'skips instance methods'
+          expect(injected_methods).to_not include(:c), 'skips instance methods'
+          expect(injected_methods).to_not include(:c=), 'skips instance methods'
         end
 
         context "with include_super = false" do
@@ -325,16 +332,18 @@ describe Interjectable do
           it "does not include super methods" do
             injected_methods = subclass.injected_methods(include_super)
 
-            expect(injected_methods).to_not include(:a)
-            expect(injected_methods).to_not include(:a=)
-            expect(injected_methods).to_not include(:b)
-            expect(injected_methods).to_not include(:b=)
+            expect(injected_methods).to_not include(:a), 'skips instance methods'
+            expect(injected_methods).to_not include(:a=), 'skips instance methods'
+            expect(injected_methods).to_not include(:b), 'skips super methods'
+            expect(injected_methods).to_not include(:b=), 'skips super methods'
+            expect(injected_methods).to_not include(:c), 'skips instance methods'
+            expect(injected_methods).to_not include(:c=), 'skips instance methods'
 
             expect(injected_methods).to match_array(
               [
                 :injected_methods,
-                :c,
-                :c=,
+                :d,
+                :d=,
               ],
             )
           end


### PR DESCRIPTION
Here's my attempt at cleaning up https://github.com/zachmargolis/interjectable/pull/12

So one thing that wasn't clear to me was if we wanted to have `Class.injected_methods` have different things from `instance.injected_methods` depending on `inject_static` or not.

I went with the simpler approach, but if there's a need, we could probably accomodate